### PR TITLE
Reset storage only on plugin installation

### DIFF
--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -5,14 +5,16 @@ import {
 } from './storage';
 import { Octokit } from "@octokit/rest";
 
-chrome.runtime.onInstalled.addListener(async () => {
-  await storeRepos([]);
+chrome.runtime.onInstalled.addListener(async (details) => {
+  if (details.reason == "install") {
+    await storeRepos([]);
 
-  chrome.action.setIcon({
-    path: "icons/yellow128.png",
-  });
+    chrome.action.setIcon({
+      path: "icons/yellow128.png",
+    });
 
-  console.log('Extension successfully installed!');
+    console.log('Extension successfully installed!');
+  }
 });
 
 export let octokit: Octokit;


### PR DESCRIPTION
`chrome.runtime.onInstalled` is triggered on multiple events: installation, plugin update and browser update (check `details.reason` enum). Actually we don't need to clear storage on browser update. What to do on plugin update (migrate?) will bw determined later.