### PR TITLE
Fix #26 Spike outcoming reviews support

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -41,9 +41,9 @@ let syncStartUnixMillis = 0;
 // ensures we don't get throttled by GitHub
 export async function throttle() {
   const secondsSinceLastSyncStart = (Date.now() - syncStartUnixMillis) / 1000;
-  if (secondsSinceLastSyncStart < gitHubCallsCounter) {
-    // to be on a safe side target 1 RPS (it's 5000 requests per hour quota):
-    const waitMs = (gitHubCallsCounter - secondsSinceLastSyncStart) * 1000;
+  if (secondsSinceLastSyncStart < 2 * gitHubCallsCounter) {
+    // to be on a safe side target 0.5 RPS (it's 5000 requests per hour quota):
+    const waitMs = (2 * gitHubCallsCounter - secondsSinceLastSyncStart) * 1000;
     console.log("Throttling GitHub calls to 1 RPS. Waiting for " + waitMs);
     await delay(waitMs);
   }
@@ -56,6 +56,7 @@ export async function throttle() {
  * No concurrent calls!
  */
 export async function sync(gitHubUserId: number): Promise<number> {
+  // #NOT_MATURE: what if it manages to exceed the quota in a single sync?
   await throttle();
 
   gitHubCallsCounter = 0;

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,14 +1,16 @@
 import "../styles/popup.scss";
+import { Octokit } from "@octokit/rest";
 import {
   getGitHubUser,
   getRepos,
   getRepoStateByFullName,
   GitHubUser,
+  MyPRReviewStatus,
   Repo,
   RepoState,
+  ReviewState,
   storeGitHubUser,
 } from "./storage";
-import { Octokit } from "@octokit/rest";
 
 document.getElementById("go-to-options").addEventListener("click", () => {
   chrome.runtime.openOptionsPage();
@@ -68,6 +70,10 @@ getGitHubUser()
     if (user && user.data && user.data.id) {
       populate();
       document.getElementById("main").style.display = "block";
+
+      setInterval(function () {
+        populate();
+      }, 60000);
     } else {
       throw new Error(
         "Could not get GitHub user. GitHub GET /user returned: " + user,
@@ -112,22 +118,40 @@ async function populate() {
   const syncFailureRepos = repos
     .filter((r) => {
       const repoState = repoStateByFullName.get(r.fullName());
-      return (
+      const noSuccessfulRecentSync =
         !repoState.lastSuccessfulSyncResult ||
-        !repoState.lastSuccessfulSyncResult.isRecent()
-      );
+        !repoState.lastSuccessfulSyncResult.isRecent();
+      return noSuccessfulRecentSync && repoState.lastSyncResult.errorMsg;
     })
     .map((r) => repoStateByFullName.get(r.fullName()));
 
   populateFromState(syncSuccessRepos, syncFailureRepos);
 }
 
+const REVIEW_REQUSTED_SVG =
+  '<svg aria-hidden="true" height="16" viewBox="0 0 16 16" width="16">\n' +
+  '    <path d="M8 4a4 4 0 1 1 0 8 4 4 0 0 1 0-8Z" fill="#9a6700"></path>\n' +
+  "</svg>";
+
+const COMMENTED_SVG =
+  '<svg aria-hidden="true" height="16" viewBox="0 0 16 16" width="16">\n' +
+  '    <path fill="#656d76" d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h4.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>\n' +
+  "</svg>";
+
+const CHANGES_REQUSTED_SVG =
+  '<svg aria-hidden="true" height="16" viewBox="0 0 16 16" width="16">\n' +
+  '    <path fill="#656d76" d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z"></path>\n' +
+  "</svg>";
+
+const APPROVED_SVG =
+  '<svg aria-hidden="true" height="16" viewBox="0 0 16 16" width="16">\n' +
+  '    <path fill="#1a7f37" d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path>\n' +
+  "</svg>";
+
 async function populateFromState(
   syncSuccessRepos: RepoState[],
   syncFailureRepos: RepoState[],
 ) {
-  // All the repos monitored should be mentioned either in repoListSection or
-  // repoWarnSection:
   const repoWarnSection = document.getElementById("repoWarn");
   if (syncFailureRepos.length > 0) {
     repoWarnSection.innerHTML =
@@ -156,12 +180,16 @@ async function populateFromState(
 
   const repoListSection = document.getElementById("repoList");
   repoListSection.innerHTML =
-    "Repos monitored: " +
-    syncSuccessRepos.map((repo) => repo.fullName).join(", ") +
-    ".<br/>Last sync: " +
-    new Date(minSuccessSyncStartUnixMillis).toLocaleString();
+    "Last sync: " +
+    new Date(minSuccessSyncStartUnixMillis).toLocaleString() +
+    "<br/>Repos monitored: " +
+    syncSuccessRepos
+      .map((repo) => repo.fullName)
+      .sort()
+      .join(", ") +
+    ".";
 
-  const reviewsRequested = syncSuccessRepos
+  const requestsForMyReviews = syncSuccessRepos
     .flatMap((repo) => {
       return repo.lastSuccessfulSyncResult.requestsForMyReview.map((v) => {
         v.repoFullName = repo.fullName;
@@ -172,30 +200,103 @@ async function populateFromState(
       (a, b) => a.firstTimeObservedUnixMillis - b.firstTimeObservedUnixMillis,
     );
 
-  const table = document.getElementById("prTable") as HTMLTableElement;
+  const myPRs = syncSuccessRepos.flatMap((repo) => {
+    return repo.lastSuccessfulSyncResult.myPRs.map((v) => {
+      v.repoFullName = repo.fullName;
+      return v;
+    });
+  });
 
-  // Iterate over the pullRequests array and create rows for each entry
-  for (let i = 0; i < reviewsRequested.length; i++) {
-    const row = table.insertRow(i + 1); // Insert rows starting from index 1
+  const reviewRequestedTable = document.getElementById(
+    "prTable",
+  ) as HTMLTableElement;
+  deleteAllRows(reviewRequestedTable);
+  const myPRsTable = document.getElementById("myPrTable") as HTMLTableElement;
+  deleteAllRows(myPRsTable);
+
+  // Iterate over the requestsForMyReviews array and create rows for each entry
+  for (let i = 0; i < requestsForMyReviews.length; i++) {
+    const row = reviewRequestedTable.insertRow(i + 1); // Insert rows starting from index 1
 
     const repoCell = row.insertCell(0);
-    repoCell.innerHTML = reviewsRequested[i].repoFullName;
+    repoCell.innerHTML = requestsForMyReviews[i].repoFullName;
 
     const prCell = row.insertCell(1);
     prCell.innerHTML =
       "<a href = '" +
-      reviewsRequested[i].pr.url +
+      requestsForMyReviews[i].pr.url +
       "' target='_blank'>" +
-      reviewsRequested[i].pr.name +
+      requestsForMyReviews[i].pr.name +
       "</a>";
 
     const hoursCell = row.insertCell(2);
     hoursCell.innerHTML =
       Math.floor(
-        (Date.now() - reviewsRequested[i].firstTimeObservedUnixMillis) /
+        (Date.now() - requestsForMyReviews[i].firstTimeObservedUnixMillis) /
           (1000 * 60 * 60),
       ) + "h";
 
     // TODO(9): add silence review request button.
+  }
+
+  // Iterate over the myPRs array and create rows for each entry
+  for (let i = 0, rowIndex = 0; i < myPRs.length; i++) {
+    const myPR = myPRs[i];
+    if (myPR.getStatus() === MyPRReviewStatus.NONE) {
+      continue;
+    }
+    rowIndex++;
+
+    const row = myPRsTable.insertRow(rowIndex); // Insert rows starting from index 1
+
+    const repoCell = row.insertCell(0);
+    repoCell.innerHTML = myPR.repoFullName;
+
+    const prCell = row.insertCell(1);
+    prCell.innerHTML =
+      "<a href = '" +
+      myPR.pr.url +
+      "' target='_blank'>" +
+      myPR.pr.name +
+      "</a>";
+
+    const statusCell = row.insertCell(2);
+
+    let hasReviewRequested = false;
+    let hasCommented = false;
+    let hasChangesRequested = false;
+    let hasApproved = false;
+    myPR.reviewerStates.forEach((reviewerState) => {
+      if (reviewerState.state === ReviewState.REQUESTED) {
+        hasReviewRequested = true;
+      } else if (reviewerState.state === ReviewState.COMMENTED) {
+        hasCommented = true;
+      } else if (reviewerState.state === ReviewState.CHANGES_REQUESTED) {
+        hasChangesRequested = true;
+      } else if (reviewerState.state === ReviewState.APPROVED) {
+        hasApproved = true;
+      }
+    });
+
+    statusCell.innerHTML = "";
+
+    if (hasApproved) {
+      statusCell.innerHTML += APPROVED_SVG;
+    }
+    if (hasCommented) {
+      statusCell.innerHTML += COMMENTED_SVG;
+    }
+    if (hasChangesRequested) {
+      statusCell.innerHTML += CHANGES_REQUSTED_SVG;
+    }
+    if (hasReviewRequested) {
+      statusCell.innerHTML += REVIEW_REQUSTED_SVG;
+    }
+  }
+
+  function deleteAllRows(htmlTableElement: HTMLTableElement) {
+    while (htmlTableElement.rows.length > 1) {
+      htmlTableElement.deleteRow(1);
+    }
   }
 }

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -29,7 +29,7 @@ setInterval(function () {
     .catch((e) => {
       console.error("Sync failed", e);
     });
-}, 10000);
+}, 30000);
 
 let syncInProgress = false;
 

--- a/static/options.html
+++ b/static/options.html
@@ -19,7 +19,7 @@
       <label for="newRepo">New repo:</label>
       <input type="text" id="newRepo" name="newRepo">
       <button type="submit">Add</button>
-      <br/>For example, sindresorhus/awesome
+      <br/>For example, artie-shevchenko/pr-review-your-turn
       <div id="addRepoError" style="color:red"></div>
     </form>
     <h1>Reset</h1>

--- a/static/popup.html
+++ b/static/popup.html
@@ -27,11 +27,20 @@
   </form>
 </div>
 <div id="main" class="container" style="display:none">
+  <h2>Outcoming reviews</h2>
   <table id="prTable">
     <tr class="prTableHeader">
       <td class="repoColumn">Repo</td>
-      <td class="prTitleColumn">Pull Request</td>
+      <td class="theirPrTitleColumn">Pull Request</td>
       <td>Hours you've ignored it for*</td>
+    </tr>
+  </table>
+  <h2>Incoming reviews</h2>
+  <table id="myPrTable">
+    <tr class="prTableHeader">
+      <td class="repoColumn">Repo</td>
+      <td class="myPrTitleColumn">Pull Request</td>
+      <td>State</td>
     </tr>
   </table>
   <span class="footnotes">&nbsp;* From the plugin's perspective. Please upvote

--- a/styles/popup.scss
+++ b/styles/popup.scss
@@ -1,5 +1,5 @@
 body {
-  background-color: #fefaa1;
+  background-color: #fffedd;
   margin: 0;
 }
 .container {
@@ -36,8 +36,11 @@ td {
 .repoColumn {
   width: 20%;
 }
-.prTitleColumn {
+.theirPrTitleColumn {
   width: 60%;
+}
+.myPrTitleColumn {
+  width: 64%;
 }
 .footnotes {
   font-size: smaller;


### PR DESCRIPTION
Out-of-scope: introduce user-configurable settings controlling ambiguities like: "Approved shouldn't contain PR if some reviewers still didn't review (there are review requests pending)". Or "Treat `COMMENTED` as `CHANGES_REQUESTED`". Unfortunately in GitHub there are quite a lot of flexibility/ambiguity around the PR review flow and whose turn is that.